### PR TITLE
New release to include vital fix

### DIFF
--- a/JTSReachability.podspec
+++ b/JTSReachability.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "JTSReachability"
-  s.version      = "1.1.0"
+  s.version      = "1.2.0"
   s.summary      = "Adaptation of Apple's Reachability with some block-based conveniences."
   s.homepage     = "https://github.com/jaredsinclair/JTSReachability"
   s.license      = { :type => 'MIT', :file => 'LICENSE'  }


### PR DESCRIPTION
The last commit fixed an issue with the JTSReachabilityResponder singleton, but the cocoa pod is pointing to an older tag. This PR includes the update to the Podspec but you'll probably have to add the tag (1.2.0) @jaredsinclair 

Thanks!